### PR TITLE
Add configuration for Editorial Tools

### DIFF
--- a/.github/workflows/editorial-tools.yml
+++ b/.github/workflows/editorial-tools.yml
@@ -1,0 +1,80 @@
+name: "[Editorial Tools] Google Chats PR Announcer"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every morning at 9AM, Mondays to Fridays
+    - cron: "0 9 * * MON-FRI"
+
+jobs:
+  # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.main.outputs.repos }}
+    steps:
+      - id: main
+        # See https://github.com/orgs/guardian/teams/developer-experience/repositories
+        run: |
+          REPOS=(
+            atom-workshop
+            crossword
+            editorial-production-metrics
+            editions-card-builder
+            editorial-preferences
+            editorial-tools-integration-tests
+            editorial-tools-platform
+            editorial-tools-production-monitoring
+            editorial-tools-user-telemetry-service
+            editorial-viewer
+            facia-tool
+            flexible-content
+            flexible-feeds
+            flexible-model
+            flexible-octopus-converter
+            flexible-octopus-model
+            flexible-snapshotter
+            grid
+            interactive-basichartool
+            login.gutools
+            media-atom-maker
+            path-manager
+            permissions
+            pinboard
+            presence-indicator
+            prosemirror-elements
+            prosemirror-invisibles
+            prosemirror-typerighter
+            remote-machines
+            rights-feeder
+            story-packages
+            tagmanager
+            ten-four_quiz-builder
+            tools-index
+            typerighter
+            workflow
+            workflow-frontend
+            youtube-pfp-player-demo
+          )
+          
+          RESULT=""
+          for repo in "${REPOS[@]}"; do
+            RESULT="$RESULT,guardian/$repo"
+          done
+          
+          # remove leading ,
+          RESULT="${RESULT:1}"
+          echo "repos=$RESULT" >> $GITHUB_OUTPUT
+  prnouncer:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: guardian/actions-prnouncer@main
+        with:
+          google-webhook-url: ${{ secrets.EDITORIAL_TOOLS_GOOGLE_WEBHOOK_URL }}
+          github-repositories: ${{ needs.setup.outputs.repos }}
+
+          # This is a fine-grained PAT for the guardian-ci user.
+          # It's got PR read permission for all repositories accessible by the user.
+          # See https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/
+          github-token: ${{ secrets.GU_REPO_READ_ACCESS }}


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds [prnouncer](https://github.com/guardian/actions-prnouncer) configuration for the Editorial Tools team.

As the only user of the [pr-exposer service](https://github.com/guardian/google-chat-bots/blob/main/pr-exposer/README.md), this should allow the team to retire the pr-exposer service. This will allow for a reduced AWS infrastructure, reduced complexity, and reduced maintenance cost.

Monetary reductions are negligible, w/PR-exposer costing ~$0.20/month.

## prnouncer vs. pr-exposer
|                        | prnouncer                 | pr-exposer                         |
|------------------------|-----------------------------------|------------------------------------|
| Configuration          | VCS                               | JSON in S3 (Composer account)      |
| Chat Message Frequency | Cron (once daily)                 | Per event on PR                    |
| Chat Threads           | One per day                       | One per PR                         |
| Chat Message Content   | Link, and title to unapproved PRs | Link, title and description to PRs |
| Runs in                | GitHub Actions                    | AWS (Composer account)             |

## Images
Here's an example message from the DevX team:

<img width="807" alt="image" src="https://user-images.githubusercontent.com/836140/197702217-e8455bfe-2092-4a4d-a53e-df83f525cadf.png">