### PR TITLE
feat: Dotcom PR announcer

### DIFF
--- a/.github/workflows/dotcom.yml
+++ b/.github/workflows/dotcom.yml
@@ -1,0 +1,49 @@
+name: "[Dotcom] Google Chats PR Announcer"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every morning at 6AM, Mondays to Fridays
+    - cron: "0 6 * * MON-FRI"
+
+jobs:
+  # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.main.outputs.repos }}
+    steps:
+      - id: main
+        run: |
+          REPOS=(
+            frontend
+            dotcom-rendering
+          )
+          
+          RESULT=""
+          for repo in "${REPOS[@]}"; do
+            RESULT="$RESULT,guardian/$repo"
+          done
+          
+          # remove leading ,
+          RESULT="${RESULT:1}"
+          echo "repos=$RESULT" >> $GITHUB_OUTPUT
+  prnouncer:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: guardian/actions-prnouncer@main
+        with:
+          google-webhook-url: ${{ secrets.DOTCOM_GOOGLE_WEBHOOK_URL }}
+          github-repositories: ${{ needs.setup.outputs.repos }}
+
+          # This is a fine-grained PAT for the guardian-ci user.
+          # It's got PR read permission for all repositories accessible by the user.
+          # See https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/
+          github-token: ${{ secrets.GU_REPO_READ_ACCESS }}
+          
+          # Ignore PRs from dependabot, and snyk-bot as there are a LOT of PRs.
+          # See:
+          #   - https://api.github.com/users/dependabot
+          #   - https://api.github.com/users/snyk-bot
+          github-ignored-users: 49699333,19733683


### PR DESCRIPTION
## What does this change?

Moves the DCR prannouncer workflow [dotcom-rendering](https://github.com/guardian/dotcom-rendering/blob/main/.github/workflows/prannouncer.yml) to this repo! (also adds Frontend to our repos to announce)

Related PR https://github.com/guardian/dotcom-rendering/pull/6359
