### PR TITLE
Adds ssm-scala to monitored repositories

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -51,6 +51,7 @@ jobs:
             security-hq
             security-platform
             service-control-policies
+            ssm-scala
             ssm-to-env
             toil
             toil-records


### PR DESCRIPTION
## What does this change?

Adds [ssm-scala](https://github.com/guardian/ssm-scala) to monitored repositories as it's currently a DevX Security repo and unmonitored!
