### PR TITLE
feat: add guardian-engineering-site config

### DIFF
--- a/.github/workflows/guardian-engineering-site.yml
+++ b/.github/workflows/guardian-engineering-site.yml
@@ -1,0 +1,17 @@
+name: "[theguardian.engineering] Google Chats PR Announcer"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every morning at 9AM, Mondays, Wednesdays and Fridays
+    - cron: "0 9 * * MON,WED,FRI"
+
+jobs:
+  prnouncer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: guardian/actions-prnouncer@main
+        with:
+          google-webhook-url: ${{ secrets.GUARDIAN_ENGINEERING_SITE_GOOGLE_WEBHOOK_URL }}
+          github-repositories: guardian/guardian-engineering-site
+          github-token: ${{ secrets.GU_REPO_READ_ACCESS }}


### PR DESCRIPTION
## What does this change?

Adds the [`guardian-engineering-site`](https://github.com/guardian/guardian-engineering-site) repo as a configuration.
That repo has only a handful of maintainers, so PRs will benefit from more visibility.

## How to test

N/A

## How can we measure success?

More PR reviews.

## Have we considered potential risks?

N/A

## Images

N/A