### PR TITLE
Ignore PRs with the `prnouncer-ignore` label

### DIFF
--- a/.github/workflows/dotcom.yml
+++ b/.github/workflows/dotcom.yml
@@ -47,3 +47,5 @@ jobs:
           #   - https://api.github.com/users/dependabot
           #   - https://api.github.com/users/snyk-bot
           github-ignored-users: 49699333,19733683
+
+          github-ignored-labels: Stale,prnouncer-ignore


### PR DESCRIPTION
Adds `prnouncer-ignore` to the ignored labels list. Because adding it here will overwrite the default setting (`Stale`), this commit also adds `Stale` to the ignored list to preserve the status quo.

This allows us to mark open, unreviewed PRs to be ignored, without having to mark them as Stale.