### PR TITLE
Add more ignorable labels

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -82,3 +82,5 @@ jobs:
 
           # By default, guardian/actions-prnouncer doesn't report PRs from Dependabot. Include them here.
           github-ignored-users: ''
+          
+          github-ignored-labels: Stale,prnouncer-ignore


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Inspired by https://github.com/guardian/prnouncer-config/pull/7. Configure prnouncer for DevX SOaR to ignore PRs with labels "Stale" or "prnouncer-ignore".

We have some long running PRs open in DevX SOaR owned repositories that are awaiting action from outside the team. Ignoring them reduces noise.

❓ This likely means we'll forget about the PR. Is this desirable?