### PR TITLE
chore: Add a new repository to DevX SOaR

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -57,6 +57,7 @@ jobs:
             toil
             toil-records
             tracker
+            waf
           )
 
           RESULT=""


### PR DESCRIPTION
## What does this change?

A new repository appears: `guardian/waf`.

![img](https://media.giphy.com/media/DRfu7BT8ZK1uo/giphy.gif)
