### PR TITLE
Swap github lens for service catalogue

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -38,7 +38,6 @@ jobs:
             elastic-search-monitor
             elasticsearch-node-rotation
             github-audit
-            github-lens
             grafana
             instance-tag-discovery
             janus-app
@@ -49,6 +48,7 @@ jobs:
             sbt-riffraff-artifact
             security-hq
             security-platform
+            service-catalogue
             service-control-policies
             snyk-tag-monitor
             ssm-scala


### PR DESCRIPTION
## What does this change?

Although github lens urls still point to the service catalogue, I'm updating the repo name to avoid confusion

## How to test

the prnouncer should still list service-catalogue PRs