### PR TITLE
Add repos to dotcom

### DIFF
--- a/.github/workflows/dotcom.yml
+++ b/.github/workflows/dotcom.yml
@@ -18,6 +18,8 @@ jobs:
           REPOS=(
             frontend
             dotcom-rendering
+            apps-rendering-api-models
+            bridget
           )
           
           RESULT=""


### PR DESCRIPTION
## What does this change?

- adds apps-rendering-api-models and bridget as these are now owned by `@guardian/dotcom-platform`
