### PR TITLE
Add 'about-us' repo to dotcom action

### DIFF
--- a/.github/workflows/dotcom.yml
+++ b/.github/workflows/dotcom.yml
@@ -20,6 +20,7 @@ jobs:
             dotcom-rendering
             apps-rendering-api-models
             bridget
+            about-us
           )
           
           RESULT=""


### PR DESCRIPTION
The [`about-us` repo](https://github.com/guardian/about-us) is part of the WebX (formerly Dotcom) team.

nb. I was thinking about renaming the workflow file to match the new team name, but I'm not sure how github actions determines what 'the same' workflow is and I didn't want to mess with the action's history without understanding that.