### PR TITLE
add new privatebin to devx repos

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -41,6 +41,7 @@ jobs:
             instance-tag-discovery
             janus-app
             node-riffraff-artifact
+            privatebin-docker
             private-infrastructure-config
             prism
             riff-raff


### PR DESCRIPTION
## What does this change?

DevX will be notified if a PR is raised against [privatebin-docker](https://github.com/guardian/privatebin-docker)