### PR TITLE
Update devx-soar.yml

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -39,7 +39,6 @@ jobs:
             elasticsearch-node-rotation
             github-audit
             grafana
-            gu-who
             instance-tag-discovery
             janus-app
             master-to-main


### PR DESCRIPTION
Remove https://github.com/guardian/gu-who from DevX SOaR config. I don't think this repository is owned by this team. Additionally, I don't think the team have access to deploy this app as it lives in Heroku.