### PR TITLE
Adds config for newsroom resilience team

### DIFF
--- a/.github/workflows/newsroom-resilience.yml
+++ b/.github/workflows/newsroom-resilience.yml
@@ -1,4 +1,4 @@
-name: "[Dotcom] Google Chats PR Announcer"
+name: "[Newsroom Resilience] Google Chats PR Announcer"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/newsroom-resilience.yml
+++ b/.github/workflows/newsroom-resilience.yml
@@ -1,0 +1,52 @@
+name: "[Dotcom] Google Chats PR Announcer"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every morning at 6AM, Mondays to Fridays
+    - cron: "0 6 * * MON-FRI"
+
+jobs:
+  # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.main.outputs.repos }}
+    steps:
+      - id: main
+        run: |
+          REPOS=(
+            newsroom-resilience-platform
+            birthdays
+            pressreader
+          )
+          
+          RESULT=""
+          for repo in "${REPOS[@]}"; do
+            RESULT="$RESULT,guardian/$repo"
+          done
+          
+          # remove leading ,
+          RESULT="${RESULT:1}"
+          echo "repos=$RESULT" >> $GITHUB_OUTPUT
+  prnouncer:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: guardian/actions-prnouncer@main
+        with:
+          google-webhook-url: ${{ secrets.NEWSREL_GOOGLE_WEBHOOK_URL }}
+          github-repositories: ${{ needs.setup.outputs.repos }}
+
+          # This is a fine-grained PAT for the guardian-ci user.
+          # It's got PR read permission for all repositories accessible by the user.
+          # See https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/
+          github-token: ${{ secrets.GU_REPO_READ_ACCESS }}
+          
+          # Ignore PRs from dependabot, and snyk-bot as there are a LOT of PRs.
+          # See:
+          #   - https://api.github.com/users/dependabot
+          #   - https://api.github.com/users/snyk-bot
+          github-ignored-users: 49699333,19733683
+
+          github-ignored-labels: Stale,prnouncer-ignore


### PR DESCRIPTION
## What does this change?

Adds [prnouncer](https://github.com/guardian/actions-prnouncer) configuration for the [Newsroom Resilience team](https://github.com/orgs/guardian/teams/newsroom-resilience).
