### PR TITLE
Add `gu-scala-steward-public-repos` to dotcom ignored users

### DIFF
--- a/.github/workflows/dotcom.yml
+++ b/.github/workflows/dotcom.yml
@@ -49,6 +49,7 @@ jobs:
           # See:
           #   - https://api.github.com/users/dependabot
           #   - https://api.github.com/users/snyk-bot
-          github-ignored-users: 49699333,19733683
+          #   - https://github.com/apps/gu-scala-steward-public-repos
+          github-ignored-users: 49699333,19733683,108136057
 
           github-ignored-labels: Stale,prnouncer-ignore


### PR DESCRIPTION
## What does this change?

Adds `gu-scala-steward-public-repos` to the list of ignored users for Dotcom. We similarly disable dependabot PRs to reduce spam.