### PR TITLE
Add image-syndication to newsroom-resilience repos

### DIFF
--- a/.github/workflows/newsroom-resilience.yml
+++ b/.github/workflows/newsroom-resilience.yml
@@ -16,8 +16,9 @@ jobs:
       - id: main
         run: |
           REPOS=(
-            newsroom-resilience-platform
             birthdays
+            image-syndication
+            newsroom-resilience-platform
             pressreader
           )
           


### PR DESCRIPTION
## What does this change?

Adds the https://github.com/guardian/image-syndication repository for Newsroom Resilience team.

## How to test

Merge this, observe PRs posted to NR channel.

## How can we measure success?

NR devs are notified of PRs that are in need of review.
