### PR TITLE
Update devx-soar.yml

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -22,14 +22,12 @@ jobs:
             actions-riff-raff
             amiable
             amigo
-            amiup
             anghammarad
             aws-account-setup
             aws-cost-management
             cdk
             cdk-playground
             cfn-private-resource-types
-            cloudformation-information
             cloudwatch-logs-management
             cognito-auth-lambdas
             deploy-tools-platform
@@ -39,7 +37,6 @@ jobs:
             dns-validation-lambda
             elastic-search-monitor
             elasticsearch-node-rotation
-            github-audit
             grafana
             instance-tag-discovery
             janus-app


### PR DESCRIPTION
Removes archived repositories, making the list more manageable.

👉🏽 [github-audit](https://github.com/guardian/github-audit) is not currently archived, but I think with [service-catalogue](https://github.com/guardian/service-catalogue) the repository is redundant?