### PR TITLE
Adds exiftool-lambda-layer to Newsroom Resilience repos

### DIFF
--- a/.github/workflows/newsroom-resilience.yml
+++ b/.github/workflows/newsroom-resilience.yml
@@ -20,6 +20,7 @@ jobs:
             image-syndication
             newsroom-resilience-platform
             pressreader
+            exiftool-lambda-layer
           )
           
           RESULT=""


### PR DESCRIPTION
## What does this change?

This layer is used by our tools, so we should watch PRs on it.
