### PR TITLE
Update editorial-tools.yml

### DIFF
--- a/.github/workflows/editorial-tools.yml
+++ b/.github/workflows/editorial-tools.yml
@@ -56,7 +56,6 @@ jobs:
             remote-machines
             rights-feeder
             s3-upload
-            screenshort
             # story-packages # bot is failing to parse response from this repo
             tagmanager
             targeting


### PR DESCRIPTION
Drop [screenshort](https://github.com/guardian/screenshort), as it has been archived.