### PR TITLE
Show PR age for dotcom

### DIFF
--- a/.github/workflows/dotcom.yml
+++ b/.github/workflows/dotcom.yml
@@ -56,3 +56,4 @@ jobs:
           #   - https://github.com/apps/gu-scala-steward-public-repos
           github-ignored-users: 49699333,19733683,108136057
           github-ignored-labels: Stale,prnouncer-ignore
+          show-pr-age: "true"


### PR DESCRIPTION
`actions-prnouncer` introduced functionality in https://github.com/guardian/actions-prnouncer/pull/19 to show the relative age of each PR.