### PR TITLE
Add slo-alerts repository to devx-soar.yml

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -51,6 +51,7 @@ jobs:
             security-platform
             service-catalogue
             simple-configuration
+            slo-alerts
             snyk-tag-monitor
             ssm-scala
             ssm-to-env


### PR DESCRIPTION
## What does this change?

We're doing a lot of work on https://github.com/guardian/slo-alerts at the moment, so I'd like to start receiving reminders about PRs for this repository.
