### PR TITLE
Configure `show-pr-age` for DevX SOaR

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -89,3 +89,5 @@ jobs:
 
           # By default, guardian/actions-prnouncer doesn't report PRs from Dependabot. Include them here.
           github-ignored-users: ''
+          
+          show-pr-age: 'true'


### PR DESCRIPTION
Add `show-pr-age` config. See https://github.com/guardian/actions-prnouncer/pull/19.