### PR TITLE
Add crosswordv2 repository for Newsroom Resilience team

### DIFF
--- a/.github/workflows/newsroom-resilience.yml
+++ b/.github/workflows/newsroom-resilience.yml
@@ -21,6 +21,7 @@ jobs:
             newsroom-resilience-platform
             pressreader
             exiftool-lambda-layer
+            crosswordv2
           )
           
           RESULT=""


### PR DESCRIPTION
## What does this change?

Adds the https://github.com/guardian/crosswordv2 repository owned by the Newsroom Resilience team.
