### PR TITLE
Add remote-machines to Newsroom Resilience repos

### DIFF
--- a/.github/workflows/newsroom-resilience.yml
+++ b/.github/workflows/newsroom-resilience.yml
@@ -22,13 +22,14 @@ jobs:
             pressreader
             exiftool-lambda-layer
             crosswordv2
+            remote-machines
           )
-          
+
           RESULT=""
           for repo in "${REPOS[@]}"; do
             RESULT="$RESULT,guardian/$repo"
           done
-          
+
           # remove leading ,
           RESULT="${RESULT:1}"
           echo "repos=$RESULT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Newsroom Resilience is doing work on the [`remote-machines`](https://github.com/guardian/remote-machines) so it will be useful to get notifications.