### PR TITLE
Add prnouncer as a DevX repo

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           REPOS=(
             .github
+            actions-prnouncer
             actions-read-private-repos
             actions-riff-raff
             amiable


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds devx as a notification target for the actions-prnouncer repo. It hasn't had any dependency updates in a while and I think this repo probably falls in our remit.
