### PR TITLE
fix: Add `guardian/cq-source-galaxies` to DevX SOaR repositories

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -33,6 +33,7 @@ jobs:
             cfn-private-resource-types
             cloudwatch-logs-management
             cognito-auth-lambdas
+            cq-source-galaxies
             deploy-tools-platform
             devx-config
             devx-docs


### PR DESCRIPTION
Adding https://github.com/guardian/cq-source-galaxies as a DevX repository.
