### PR TITLE
Security team are no longer responsible for tracker

### DIFF
--- a/.github/workflows/devx-security.yml
+++ b/.github/workflows/devx-security.yml
@@ -29,7 +29,6 @@ jobs:
             service-catalogue
             snyk-tag-monitor
             ssm-scala
-            tracker
             waf
           )
 


### PR DESCRIPTION
## What does this change?

Don't alert security team about tracker PRs
