### PR TITLE
Add `riffraff-platform` to list of repos owned by DevX SoAR

### DIFF
--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -47,6 +47,7 @@ jobs:
             private-infrastructure-config
             prism
             riff-raff
+            riffraff-platform
             service-catalogue
             simple-configuration
             slo-alerts


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the new riffraff-platform repo to the list of repos owned by DevX SoAR