### PR TITLE
update devx teams in links

### DIFF
--- a/.github/workflows/devx-security.yml
+++ b/.github/workflows/devx-security.yml
@@ -15,7 +15,7 @@ jobs:
       repos: ${{ steps.main.outputs.repos }}
     steps:
       - id: main
-        # See https://github.com/orgs/guardian/teams/developer-experience/repositories
+        # See https://github.com/orgs/guardian/teams/devx-security/repositories
         run: |
           REPOS=(
             .github

--- a/.github/workflows/devx-soar.yml
+++ b/.github/workflows/devx-soar.yml
@@ -15,7 +15,9 @@ jobs:
       repos: ${{ steps.main.outputs.repos }}
     steps:
       - id: main
-        # See https://github.com/orgs/guardian/teams/developer-experience/repositories
+        # See https://github.com/orgs/guardian/teams/devx-operations/repositories
+        # See https://github.com/orgs/guardian/teams/devx-reliability/repositories
+        # See https://github.com/orgs/guardian/teams/devx-security/repositories
         run: |
           REPOS=(
             .github


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the links in the Devx SOaR and Security configs to link to the sub-teams as `developer-experience` is deprecated.