### PR TITLE
Specify in README that EMs can add secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ It's useful to have a robot remind you what PRs are awaiting review,
 rather than making the contributor feel guilty about reminding you!
 
 ## How?
-- Create a webhook in your Chat channel
+1. Create a webhook in your Chat channel
   - append `&threadKey={threadKey}` to the Webhook URL to get threading
-- Add the webhook as a secret to this repository
-- Create a Workflow file in [./github/workflows](.github/workflows)
-- Merge and wait for the robot to wake up
+2. Ask someone with admin access to add the webhook as a secret to this repository. All Engineering Managers should hace access by default!
+3. Create a Workflow file in [./github/workflows](.github/workflows)
+4. Merge and wait for the robot to wake up


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adding Engineering Manager access to the README so that developers don't need to wait on DevX to add a workflow.
