### PR TITLE
remove irrelevant repos from the list

### DIFF
--- a/.github/workflows/devx-security.yml
+++ b/.github/workflows/devx-security.yml
@@ -24,11 +24,9 @@ jobs:
             bucket-blocker
             janus-app
             privatebin-docker
-            private-infrastructure-config
             security-hq
             security-platform
             service-catalogue
-            snyk-tag-monitor
             ssm-scala
             waf
           )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove archived repos/repos no longer owned by the security team from the list