### PR TITLE
Only post once per week

### DIFF
--- a/.github/workflows/interviews.yml
+++ b/.github/workflows/interviews.yml
@@ -3,8 +3,8 @@ name: "[Interviews] Google Chats PR Announcer"
 on:
   workflow_dispatch:
   schedule:
-    # Every morning at 9AM, Mondays to Fridays
-    - cron: "0 9 * * MON-FRI"
+    # Every Friday morning at 9AM
+    - cron: "0 9 * * FRI"
 
 jobs:
   prnouncer:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Reduces the frequency of the prnouncer action for the interviews repo to once per week.

The channel that this action posts to is a very quiet one (as is the repo it monitors), so the last 25 messages are from prnouncer, concerning the same 2 PRs.

This is partly due to the PRs being quite long-lasting, but this seems likely to happen for PR in this repo, which no one really 'owns'. With alerts once per week PRs will still get surfaced, but there will be a bit less noise in the channel, so it seems like a worthwhile tradeoff.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
