### PR TITLE
Reschedule notifications for devx-security space

### DIFF
--- a/.github/workflows/devx-security.yml
+++ b/.github/workflows/devx-security.yml
@@ -3,9 +3,9 @@ name: "[DevX Security] Google Chats PR Announcer"
 on:
   workflow_dispatch:
   schedule:
-    # Every morning at 9:30AM UTC, Mondays to Fridays
+    # Every morning at 7 AM UTC, Mondays to Fridays
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron: "30 9 * * MON-FRI"
+    - cron: "0 7 * * MON-FRI"
 
 jobs:
   # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job


### PR DESCRIPTION
We want to get notifications before we start work so that they get top priority at the start of the day.