### PR TITLE
chore: Add devenv repo to devx-security list

### DIFF
--- a/.github/workflows/devx-security.yml
+++ b/.github/workflows/devx-security.yml
@@ -21,6 +21,7 @@ jobs:
             .github
             amiable
             aws-account-setup
+            devenv
             fsbp-tools
             cq-source-github-languages
             cq-source-image-packages


### PR DESCRIPTION
It would be good to be aware of changes to the [devenv](https://github.com/guardian/devenv) repo now that we're all working on it.