### PR TITLE
chore: Add `guardian/actions-static-site` to RelOps list

### DIFF
--- a/.github/workflows/devx-relops.yml
+++ b/.github/workflows/devx-relops.yml
@@ -22,6 +22,7 @@ jobs:
             actions-prnouncer
             actions-read-private-repos
             actions-riff-raff
+            actions-static-site
             amiable
             amigo
             anghammarad


### PR DESCRIPTION
## What does this change?
Adds https://github.com/guardian/actions-static-site to the DevX RelOps repository list.
