### PR TITLE
Run bot PRs on a different schedule

### DIFF
--- a/.github/workflows/media-and-feeds.yml
+++ b/.github/workflows/media-and-feeds.yml
@@ -3,6 +3,8 @@ name: "[Media & Feeds] Google Chats PR Announcer"
 on:
   workflow_dispatch:
   schedule:
+    # Every morning at 9AM Mondays
+    - cron: "0 9 * * 1"
      # Every morning at 9AM Thursdays
     - cron: "0 9 * * 4"
 
@@ -62,6 +64,7 @@ jobs:
           owner: guardian
 
       - name: 'Human PRs'
+        if: github.event.schedule == '0 9 * * 1'
         uses: guardian/actions-prnouncer@main
         with:
           google-webhook-url: ${{ secrets.NEWSREL_GOOGLE_WEBHOOK_URL }}
@@ -77,6 +80,7 @@ jobs:
           github-ignored-labels: Stale,prnouncer-ignore
 
       - name: 'Bot PRs'
+        if: github.event.schedule == '0 9 * * 4'
         uses: guardian/actions-prnouncer@main
         with:
           google-webhook-url: ${{ secrets.NEWSREL_GOOGLE_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Run the human PRs and bot PRs on a different schedule

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
