### PR TITLE
feat(devx-relops): Also run dependency PRs on Wednesday

### DIFF
--- a/.github/workflows/devx-relops.yml
+++ b/.github/workflows/devx-relops.yml
@@ -91,8 +91,8 @@ jobs:
         run: echo "CURRENT_DAY=$(date +'%a')" >> $GITHUB_ENV
 
       - name: Announce dependency update PRs
-        # Only run on Mondays to avoid daily noise from dependency bots (or on manual execution)
-        if: github.event_name == 'workflow_dispatch' || env.CURRENT_DAY == 'Mon'
+        # Run on Mondays and Wednesdays to avoid too much noise from dependency bots (or on manual execution)
+        if: github.event_name == 'workflow_dispatch' || env.CURRENT_DAY == 'Mon' || env.CURRENT_DAY == 'Wed'
         uses: guardian/actions-prnouncer@main
         with:
           google-webhook-url: ${{ secrets.DEVX_GOOGLE_WEBHOOK_URL }}


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/prnouncer-config/pull/91, dependency PRs were switched to Monday only to reduce noise.

This change tweaks this to also run on Wednesday to somewhat account for Bank Holidays. It hopefully also makes it easier to find PRs that still need review, increasing the chance of reaching inbox zero.

DevX RelOps have a weekly rota where the person on rota is charged with reviewing these PRs. A couple of times now, when I'm on rota, I only start doing this mid-week. As the list is only published on Monday, the first task is to find the message. This change should improve this scenario.