### PR TITLE
Update PR notification schedule to use London time

### DIFF
--- a/.github/workflows/devx-security.yml
+++ b/.github/workflows/devx-security.yml
@@ -3,9 +3,10 @@ name: "[DevX Security] Google Chats PR Announcer"
 on:
   workflow_dispatch:
   schedule:
-    # Every morning at 7 AM UTC, Mondays to Fridays
+    # Every weekday morning at 7 AM
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron: "0 7 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job


### PR DESCRIPTION
Making use of the relatively new [timezone feature](https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/) to give a consistent year-round schedule.
